### PR TITLE
Fix all dashboard launch errors

### DIFF
--- a/src/vehicle_trajectory_prediction/models/ensemble.py
+++ b/src/vehicle_trajectory_prediction/models/ensemble.py
@@ -409,6 +409,47 @@ class EnsemblePredictor(BaseTrajectoryPredictor):
         
         return combined_pred
     
+    def predict_batch(self, trajectories: List[Trajectory],
+                     prediction_horizon: Optional[int] = None,
+                     prediction_frequency: Optional[float] = None) -> List[PredictionResult]:
+        """
+        Predict future trajectories for multiple inputs using ensemble of models.
+        
+        Args:
+            trajectories: List of input trajectories for prediction
+            prediction_horizon: Optional prediction horizon override
+            prediction_frequency: Optional prediction frequency override
+            
+        Returns:
+            List of PredictionResult with combined predictions
+        """
+        if not self.is_trained:
+            raise RuntimeError("Ensemble must be trained before prediction")
+        
+        if not self.base_models:
+            raise ValueError("No models in ensemble")
+        
+        results = []
+        for trajectory in trajectories:
+            try:
+                result = self.predict(trajectory, prediction_horizon, prediction_frequency)
+                results.append(result)
+            except Exception as e:
+                logger.warning(f"Batch prediction failed for trajectory: {e}")
+                # Create a default result with zeros
+                default_result = PredictionResult(
+                    predicted_points=[],
+                    timestamps=[],
+                    x_positions=[],
+                    y_positions=[],
+                    velocities=[],
+                    accelerations=[],
+                    headings=[]
+                )
+                results.append(default_result)
+        
+        return results
+    
     def update_weights_online(self, true_trajectory: Trajectory, 
                             predicted_trajectory: PredictionResult):
         """


### PR DESCRIPTION
Implement the missing `predict_batch` abstract method in `EnsemblePredictor` to fix dashboard startup errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c951fb7-6d4a-4adc-bc01-f56d31d978a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c951fb7-6d4a-4adc-bc01-f56d31d978a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

